### PR TITLE
[Reminder Pause] Improve paused reminder indicator

### DIFF
--- a/WaterMe/WaterMe/ReminderVesselMain/ReminderVesselEdit/ReminderTableViewCell.swift
+++ b/WaterMe/WaterMe/ReminderVesselMain/ReminderVesselEdit/ReminderTableViewCell.swift
@@ -33,6 +33,7 @@ class ReminderTableViewCell: UITableViewCell {
     @IBOutlet private weak var middleLabel: UILabel?
     @IBOutlet private weak var bottomLabel: UILabel?
     @IBOutlet private weak var emojiImageView: EmojiImageView?
+    @IBOutlet private weak var muteIndicator: UILabel?
 
     @IBOutlet private weak var leadingConstraint: NSLayoutConstraint?
     @IBOutlet private weak var trailingConstraint: NSLayoutConstraint?
@@ -51,7 +52,9 @@ class ReminderTableViewCell: UITableViewCell {
                                         font: .selectableTableViewCellHelper)
         self.middleLabel?.attributedText = helper + interval
         self.emojiImageView?.setKind(reminder.kind)
+
         if !reminder.isEnabled {
+            self.muteIndicator?.isHidden = false
             self.contentView.alpha = 0.3
         }
         
@@ -96,6 +99,7 @@ class ReminderTableViewCell: UITableViewCell {
         self.middleLabel?.isHidden = false
         self.bottomLabel?.isHidden = false
         self.emojiImageView?.setKind(nil)
+        self.muteIndicator?.isHidden = true
         self.contentView.alpha = 100
     }
     

--- a/WaterMe/WaterMe/ReminderVesselMain/ReminderVesselEdit/ReminderTableViewCell.swift
+++ b/WaterMe/WaterMe/ReminderVesselMain/ReminderVesselEdit/ReminderTableViewCell.swift
@@ -52,7 +52,7 @@ class ReminderTableViewCell: UITableViewCell {
         self.middleLabel?.attributedText = helper + interval
         self.emojiImageView?.setKind(reminder.kind)
         if !reminder.isEnabled {
-            self.backgroundColor = UIColor.red // TODO devise a better UI to convey disabled reminders
+            self.contentView.alpha = 0.3
         }
         
         // do stuff that is case specific
@@ -96,7 +96,7 @@ class ReminderTableViewCell: UITableViewCell {
         self.middleLabel?.isHidden = false
         self.bottomLabel?.isHidden = false
         self.emojiImageView?.setKind(nil)
-        self.backgroundColor = nil
+        self.contentView.alpha = 100
     }
     
     override func prepareForReuse() {

--- a/WaterMe/WaterMe/ReminderVesselMain/ReminderVesselEdit/ReminderTableViewCell.xib
+++ b/WaterMe/WaterMe/ReminderVesselMain/ReminderVesselEdit/ReminderTableViewCell.xib
@@ -49,6 +49,13 @@
                             </label>
                         </subviews>
                     </stackView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🔕" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mXb-Bl-isq">
+                        <rect key="frame" x="262" y="11" width="42" height="42"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
                 <constraints>
                     <constraint firstItem="pJ1-Qa-CHB" firstAttribute="leading" secondItem="cqQ-mh-PX3" secondAttribute="trailing" constant="12" id="GOh-yB-03Q"/>
@@ -66,6 +73,7 @@
                 <outlet property="emojiImageView" destination="cqQ-mh-PX3" id="myK-j7-8jj"/>
                 <outlet property="leadingConstraint" destination="XNp-4R-Tf3" id="dwP-lr-Jfi"/>
                 <outlet property="middleLabel" destination="XRB-j7-927" id="Tcd-A2-q8R"/>
+                <outlet property="muteIndicator" destination="mXb-Bl-isq" id="GG2-mC-YeG"/>
                 <outlet property="topConstraint" destination="Jjx-TH-D2S" id="nCP-15-0vw"/>
                 <outlet property="topLabel" destination="Icd-mF-8hY" id="wwr-8S-cOk"/>
                 <outlet property="trailingConstraint" destination="vux-3O-Ynd" id="oG7-O6-ekb"/>


### PR DESCRIPTION
- use opacity, instead of bright red, to indicate that a reminder is paused
- show a mute icon on paused reminders (use `🔕` as a placeholder for now until design)

<img src="https://user-images.githubusercontent.com/189989/114301328-416e0780-9aff-11eb-8995-983c81458f77.png" width="180"/>
